### PR TITLE
feat(cli): add automatic update check

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -32,13 +32,15 @@ import { clearAuth } from './lib/auth-store.js';
 import { DEFAULT_INTERVAL_MS } from './lib/daemon.js';
 import { setKey, removeKey, listKeys, type ProviderKeyName } from './lib/keys.js';
 import * as out from './lib/output.js';
+import { checkForUpdates } from './lib/version-check.js';
 
 const program = new Command();
 
 program
   .name('awarts')
   .description('Track your AI coding spend across Claude, Codex, Gemini & Antigravity')
-  .version('0.1.0');
+  .version('0.2.4')
+  .hook('preAction', () => checkForUpdates());
 
 // ─── login ──────────────────────────────────────────────────────────────
 program

--- a/cli/src/lib/version-check.ts
+++ b/cli/src/lib/version-check.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import * as out from './output.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function getLocalVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+export async function checkForUpdates(): Promise<void> {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 3000);
+
+    const res = await fetch('https://registry.npmjs.org/awarts/latest', {
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+
+    if (!res.ok) return;
+
+    const data = (await res.json()) as { version?: string };
+    const latest = data.version;
+    const current = getLocalVersion();
+
+    if (latest && latest !== current) {
+      out.info(`Update available: ${current} → ${latest}. Run: npm i -g awarts@latest`);
+    }
+  } catch {
+    // Silent fail — don't block CLI usage
+  }
+}


### PR DESCRIPTION
## Summary

- Adds version check that runs before each CLI command
- Fetches latest version from npm registry with 3s timeout
- Notifies user if a newer version is available
- Silently fails to avoid blocking normal CLI usage

Closes #5

## Test plan

- [ ] Run `awarts status` — should not show update notice if on latest
- [ ] Downgrade locally, run again — should show "Update available: x.x.x → y.y.y"
- [ ] Disconnect network, run command — should proceed normally without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI now automatically checks for available updates on startup. When a newer version is available, a suggestion message displays with upgrade instructions.

* **Updates**
  * CLI version updated to 0.2.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->